### PR TITLE
Display error details only to admin users.

### DIFF
--- a/about.go
+++ b/about.go
@@ -24,7 +24,7 @@ var aboutHTML = template.Must(template.New("").Parse(`<html>
 		<div style="max-width: 800px; margin: 0 auto 100px auto;">`))
 
 func initAbout(notifications notifications.Service, users users.Service) {
-	http.Handle("/about", userMiddleware{httputil.ErrorHandler(func(w http.ResponseWriter, req *http.Request) error {
+	http.Handle("/about", userMiddleware{httputil.ErrorHandler(users, func(w http.ResponseWriter, req *http.Request) error {
 		if req.Method != "GET" {
 			return httputil.MethodError{Allowed: []string{"GET"}}
 		}

--- a/blog.go
+++ b/blog.go
@@ -110,7 +110,7 @@ func initBlog(issuesService issues.Service, blog issues.RepoSpec, notifications 
 	}
 	issuesApp := issuesapp.New(onlyShurcoolCreatePosts, users, opt)
 
-	blogHandler := userMiddleware{httputil.ErrorHandler(func(w http.ResponseWriter, req *http.Request) error {
+	blogHandler := userMiddleware{httputil.ErrorHandler(users, func(w http.ResponseWriter, req *http.Request) error {
 		prefixLen := len("/blog")
 		if prefix := req.URL.Path[:prefixLen]; req.URL.Path == prefix+"/" {
 			baseURL := prefix

--- a/http/issues_test.go
+++ b/http/issues_test.go
@@ -53,17 +53,19 @@ func (m mockUsers) GetAuthenticated(ctx context.Context) (users.User, error) {
 }
 
 func init() {
+	users := mockUsers{}
+
 	// Create a mock backend service implementation with sample data.
-	issuesService, err := fs.NewService(webdav.Dir(filepath.Join("testdata", "issues")), nil, mockUsers{})
+	issuesService, err := fs.NewService(webdav.Dir(filepath.Join("testdata", "issues")), nil, users)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
 	// Register the issues API handler.
 	issuesAPIHandler := httphandler.Issues{Issues: issuesService}
-	http.Handle("/api/issues/list", httputil.ErrorHandler(issuesAPIHandler.List))
-	http.Handle("/api/issues/count", httputil.ErrorHandler(issuesAPIHandler.Count))
-	http.Handle("/api/issues/list-comments", httputil.ErrorHandler(issuesAPIHandler.ListComments))
+	http.Handle("/api/issues/list", httputil.ErrorHandler(users, issuesAPIHandler.List))
+	http.Handle("/api/issues/count", httputil.ErrorHandler(users, issuesAPIHandler.Count))
+	http.Handle("/api/issues/list-comments", httputil.ErrorHandler(users, issuesAPIHandler.ListComments))
 }
 
 var issuesClient = httpapi.NewIssues("", "")

--- a/httphandler/issues.go
+++ b/httphandler/issues.go
@@ -1,6 +1,7 @@
 package httphandler
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -50,7 +51,7 @@ func (h Issues) ListComments(w http.ResponseWriter, req *http.Request) error {
 	repo := issues.RepoSpec{URI: q.Get("RepoURI")}
 	id, err := strconv.ParseUint(q.Get("ID"), 10, 64)
 	if err != nil {
-		return httputil.HTTPError{Code: http.StatusBadRequest, Err: err}
+		return httputil.HTTPError{Code: http.StatusBadRequest, Err: fmt.Errorf("parsing ID query parameter: %v", err)}
 	}
 	var opt *issues.ListOptions
 	if s, err := strconv.Atoi(q.Get("Opt.Start")); err == nil {
@@ -80,7 +81,7 @@ func (h Issues) EditComment(w http.ResponseWriter, req *http.Request) error {
 	repo := issues.RepoSpec{URI: q.Get("RepoURI")}
 	id, err := strconv.ParseUint(q.Get("ID"), 10, 64)
 	if err != nil {
-		return httputil.HTTPError{Code: http.StatusBadRequest, Err: err}
+		return httputil.HTTPError{Code: http.StatusBadRequest, Err: fmt.Errorf("parsing ID query parameter: %v", err)}
 	}
 	if err := req.ParseForm(); err != nil {
 		return httputil.HTTPError{Code: http.StatusBadRequest, Err: err}
@@ -88,7 +89,7 @@ func (h Issues) EditComment(w http.ResponseWriter, req *http.Request) error {
 	var cr issues.CommentRequest
 	cr.ID, err = strconv.ParseUint(req.PostForm.Get("ID"), 10, 64) // TODO: Automate this conversion process.
 	if err != nil {
-		return httputil.HTTPError{Code: http.StatusBadRequest, Err: err}
+		return httputil.HTTPError{Code: http.StatusBadRequest, Err: fmt.Errorf("parsing ID form parameter: %v", err)}
 	}
 	if body := req.PostForm["Body"]; len(body) != 0 {
 		cr.Body = &body[0]

--- a/idiomaticgo.go
+++ b/idiomaticgo.go
@@ -26,7 +26,7 @@ var idiomaticGoHTML = template.Must(template.New("").Parse(`<html>
 	<body>`))
 
 func initIdiomaticGo(issues issues.Service, notifications notifications.Service, usersService users.Service) {
-	http.Handle("/idiomatic-go", userMiddleware{httputil.ErrorHandler(func(w http.ResponseWriter, req *http.Request) error {
+	http.Handle("/idiomatic-go", userMiddleware{httputil.ErrorHandler(usersService, func(w http.ResponseWriter, req *http.Request) error {
 		if req.Method != "GET" {
 			return httputil.MethodError{Allowed: []string{"GET"}}
 		}

--- a/index.go
+++ b/index.go
@@ -56,7 +56,7 @@ func initIndex(notifications notifications.Service, users users.Service) http.Ha
 			time.Sleep(time.Minute)
 		}
 	}()
-	return userMiddleware{httputil.ErrorHandler(h.ServeHTTP)}
+	return userMiddleware{httputil.ErrorHandler(users, h.ServeHTTP)}
 }
 
 func fetchActivity() ([]*github.Event, map[string]*github.RepositoryCommit, error) {

--- a/issues.go
+++ b/issues.go
@@ -26,10 +26,10 @@ func newIssuesService(root webdav.FileSystem, notifications notifications.Extern
 func initIssues(issuesService issues.Service, notifications notifications.Service, users users.Service) error {
 	// Register HTTP API endpoint.
 	issuesAPIHandler := httphandler.Issues{Issues: issuesService}
-	http.Handle("/api/issues/list", userMiddleware{httputil.ErrorHandler(issuesAPIHandler.List)})
-	http.Handle("/api/issues/count", userMiddleware{httputil.ErrorHandler(issuesAPIHandler.Count)})
-	http.Handle("/api/issues/list-comments", userMiddleware{httputil.ErrorHandler(issuesAPIHandler.ListComments)})
-	http.Handle("/api/issues/edit-comment", userMiddleware{httputil.ErrorHandler(issuesAPIHandler.EditComment)})
+	http.Handle("/api/issues/list", userMiddleware{httputil.ErrorHandler(users, issuesAPIHandler.List)})
+	http.Handle("/api/issues/count", userMiddleware{httputil.ErrorHandler(users, issuesAPIHandler.Count)})
+	http.Handle("/api/issues/list-comments", userMiddleware{httputil.ErrorHandler(users, issuesAPIHandler.ListComments)})
+	http.Handle("/api/issues/edit-comment", userMiddleware{httputil.ErrorHandler(users, issuesAPIHandler.EditComment)})
 
 	opt := issuesapp.Options{
 		Notifications: notifications,
@@ -102,7 +102,7 @@ func initIssues(issuesService issues.Service, notifications notifications.Servic
 		{URI: "dmitri.shuralyov.com/idiomatic-go"},
 	} {
 		repoSpec := repoSpec
-		issuesHandler := userMiddleware{httputil.ErrorHandler(func(w http.ResponseWriter, req *http.Request) error {
+		issuesHandler := userMiddleware{httputil.ErrorHandler(users, func(w http.ResponseWriter, req *http.Request) error {
 			prefixLen := len("/issues/") + len(repoSpec.URI)
 			if prefix := req.URL.Path[:prefixLen]; req.URL.Path == prefix+"/" {
 				baseURL := prefix

--- a/notifications.go
+++ b/notifications.go
@@ -50,7 +50,7 @@ func initNotifications(root webdav.FileSystem, users users.Service) (notificatio
 
 	// Register HTTP API endpoint.
 	notificationsAPIHandler := httphandler.Notifications{Notifications: service}
-	http.Handle("/api/notifications/count", userMiddleware{httputil.ErrorHandler(notificationsAPIHandler.Count)})
+	http.Handle("/api/notifications/count", userMiddleware{httputil.ErrorHandler(users, notificationsAPIHandler.Count)})
 
 	// Register notifications app endpoints.
 	opt := notificationsapp.Options{
@@ -105,7 +105,7 @@ func initNotifications(root webdav.FileSystem, users users.Service) (notificatio
 	}
 	notificationsApp := notificationsapp.New(service, users, opt)
 
-	notificationsHandler := userMiddleware{httputil.ErrorHandler(func(w http.ResponseWriter, req *http.Request) error {
+	notificationsHandler := userMiddleware{httputil.ErrorHandler(users, func(w http.ResponseWriter, req *http.Request) error {
 		prefixLen := len("/notifications")
 		if prefix := req.URL.Path[:prefixLen]; req.URL.Path == prefix+"/" {
 			baseURL := prefix

--- a/packages.go
+++ b/packages.go
@@ -27,7 +27,7 @@ var packagesHTML = template.Must(template.New("").Parse(`<html>
 	<body>`))
 
 func initPackages(notifications notifications.Service, usersService users.Service) {
-	http.Handle("/packages", userMiddleware{httputil.ErrorHandler(func(w http.ResponseWriter, req *http.Request) error {
+	http.Handle("/packages", userMiddleware{httputil.ErrorHandler(usersService, func(w http.ResponseWriter, req *http.Request) error {
 		if req.Method != "GET" {
 			return httputil.MethodError{Allowed: []string{"GET"}}
 		}

--- a/resume.go
+++ b/resume.go
@@ -41,7 +41,7 @@ const googleAnalytics = `<script>
 
 // resumeJSCSS contains /resume.{js,css}.
 func initResume(resumeJSCSS http.Handler, reactions reactions.Service, notifications notifications.Service, usersService users.Service) {
-	http.Handle("/resume", userMiddleware{httputil.ErrorHandler(func(w http.ResponseWriter, req *http.Request) error {
+	http.Handle("/resume", userMiddleware{httputil.ErrorHandler(usersService, func(w http.ResponseWriter, req *http.Request) error {
 		if req.Method != "GET" {
 			return httputil.MethodError{Allowed: []string{"GET"}}
 		}

--- a/talks.go
+++ b/talks.go
@@ -34,7 +34,7 @@ func initTalks(root http.FileSystem, notifications notifications.Service, users 
 	tmpl = tmpl.Funcs(template.FuncMap{"playable": func(present.Code) bool { return false }})
 	tmpl = template.Must(vfstemplate.ParseFiles(presentdata.Assets, tmpl, "/templates/action.tmpl", "/templates/slides.tmpl"))
 
-	talksHandler := http.StripPrefix("/talks", userMiddleware{httputil.ErrorHandler((&talksHandler{
+	talksHandler := http.StripPrefix("/talks", userMiddleware{httputil.ErrorHandler(users, (&talksHandler{
 		base:   "/talks",
 		fs:     root,
 		slides: tmpl,

--- a/talks.go
+++ b/talks.go
@@ -27,7 +27,7 @@ import (
 // initTalks registers a talks handler with root as talks content source.
 func initTalks(root http.FileSystem, notifications notifications.Service, users users.Service) {
 	// Host static files that slides need.
-	http.Handle("/static/", httpgzip.FileServer(presentdata.Assets, httpgzip.FileServerOptions{ServeError: httpgzip.Detailed}))
+	http.Handle("/static/", userMiddleware{httpgzip.FileServer(presentdata.Assets, httpgzip.FileServerOptions{ServeError: detailedForAdmin{Users: users}.ServeError})})
 
 	// Create a template for slides.
 	tmpl := present.Template()


### PR DESCRIPTION
This PR completes the following TODO:

```
// TODO: Only display error details to SiteAdmin users?
```

A lot of lines touched, but the task is done.

Most of the code changes are caused by the required change to signature of `httputil.ErrorHandler`. The only actual logic changes are in `httputil.errorHandler.ServeHTTP`, `sessionsHandler.ServeHTTP`, and in `indexHandler.ServeHTTP` for activity errors.