### PR TITLE
Use Go font family.

### DIFF
--- a/about.go
+++ b/about.go
@@ -24,6 +24,7 @@ var aboutHTML = template.Must(template.New("").Parse(`<html>
 		<title>Dmitri Shuralyov - About</title>
 		<link href="/icon.png" rel="icon" type="image/png">
 		<meta name="viewport" content="width=device-width">
+		<link href="/assets/fonts/fonts.css" rel="stylesheet" type="text/css">
 		<link href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
 		<link href="/assets/about/style.css" rel="stylesheet" type="text/css">
 		{{if .Production}}` + googleAnalytics + `{{end}}

--- a/assets/_data/about/style.css
+++ b/assets/_data/about/style.css
@@ -1,6 +1,6 @@
 body {
 	margin: 20px;
-	font-family: sans-serif;
+	font-family: Go;
 	font-size: 16px;
 	color: rgb(35, 35, 35);
 }

--- a/assets/_data/blog/style.css
+++ b/assets/_data/blog/style.css
@@ -1,6 +1,6 @@
 body {
 	margin: 20px;
-	font-family: sans-serif;
+	font-family: Go;
 }
 
 ul.post-meta {

--- a/assets/_data/idiomaticgo/style.css
+++ b/assets/_data/idiomaticgo/style.css
@@ -1,6 +1,6 @@
 body {
 	margin: 20px;
-	font-family: sans-serif;
+	font-family: Go;
 }
 
 /* This is needed to make anchor visible... Can be cleaned up. */

--- a/assets/_data/index/style.css
+++ b/assets/_data/index/style.css
@@ -1,6 +1,6 @@
 body {
 	margin: 20px;
-	font-family: sans-serif;
+	font-family: Go;
 	font-size: 16px;
 	color: rgb(35, 35, 35);
 }
@@ -62,6 +62,6 @@ div.activity {
 	color: #4183c4;
 }
 .activity div.details code {
-	font-family: monospace;
+	font-family: "Go Mono";
 	font-size: 12px;
 }

--- a/assets/_data/packages/style.css
+++ b/assets/_data/packages/style.css
@@ -1,6 +1,6 @@
 body {
 	margin: 20px;
-	font-family: sans-serif;
+	font-family: Go;
 	font-size: 16px;
 	color: rgb(35, 35, 35);
 }

--- a/assets/_data/projects/style.css
+++ b/assets/_data/projects/style.css
@@ -1,6 +1,6 @@
 body {
 	margin: 20px;
-	font-family: sans-serif;
+	font-family: Go;
 }
 h1 {
 	margin: 20px 0;
@@ -13,4 +13,9 @@ h2 {
 	font-size: 20px;
 	background: #e0ebf5;
 	padding: 2px 5px;
+}
+pre {
+	font-family: "Go Mono";
+	font-size: 12px;
+	line-height: 1.3;
 }

--- a/assets/_data/talks/style.css
+++ b/assets/_data/talks/style.css
@@ -1,6 +1,6 @@
 body {
 	margin: 20px;
-	font-family: sans-serif;
+	font-family: Go;
 	font-size: 16px;
 }
 a,

--- a/assets/assets.go
+++ b/assets/assets.go
@@ -13,6 +13,13 @@ import (
 	"github.com/shurcooL/httpfs/vfsutil"
 )
 
+// Assets contains assets for home.
+var Assets = union.New(map[string]http.FileSystem{
+	"/assets":     gopherjs_http.NewFS(http.Dir(importPathToDir("github.com/shurcooL/home/assets/_data"))),
+	"/resume.js":  gopherjs_http.Package("github.com/shurcooL/resume/frontend"),
+	"/resume.css": vfsutil.File(filepath.Join(importPathToDir("github.com/shurcooL/resume/frontend"), "style.css")),
+})
+
 func importPathToDir(importPath string) string {
 	p, err := build.Import(importPath, "", build.FindOnly)
 	if err != nil {
@@ -20,10 +27,3 @@ func importPathToDir(importPath string) string {
 	}
 	return p.Dir
 }
-
-// Assets contains assets for home.
-var Assets = union.New(map[string]http.FileSystem{
-	"/assets":     gopherjs_http.NewFS(http.Dir(importPathToDir("github.com/shurcooL/home/assets/_data"))),
-	"/resume.js":  gopherjs_http.Package("github.com/shurcooL/resume/frontend"),
-	"/resume.css": vfsutil.File(filepath.Join(importPathToDir("github.com/shurcooL/resume/frontend"), "style.css")),
-})

--- a/assets/external.go
+++ b/assets/external.go
@@ -1,0 +1,14 @@
+package assets
+
+import (
+	"github.com/shurcooL/gofontwoff"
+	"github.com/shurcooL/reactions/emojis"
+)
+
+var (
+	// Fonts contains the Go font family WOFF data.
+	Fonts = gofontwoff.Assets
+
+	// Emojis contains emojis image data.
+	Emojis = emojis.Assets
+)

--- a/blog.go
+++ b/blog.go
@@ -27,6 +27,10 @@ var blogHTML = template.Must(template.New("").Parse(`<html>
 		<meta name="viewport" content="width=device-width">
 		<link href="/assets/fonts/fonts.css" rel="stylesheet" type="text/css">
 		<link href="/blog/assets/gfm/gfm.css" rel="stylesheet" type="text/css">
+		<style type="text/css">
+			.markdown-body { font-family: Go; }
+			tt, code, pre  { font-family: "Go Mono"; }
+		</style>
 		<link href="/assets/blog/style.css" rel="stylesheet" type="text/css">
 		<script async src="/assets/blog/blog.js"></script>
 		{{if .Production}}` + googleAnalytics + `{{end}}
@@ -50,7 +54,7 @@ func initBlog(issuesService issues.Service, blog issues.RepoSpec, notifications 
 <style type="text/css">
 	body {
 		margin: 20px;
-		font-family: sans-serif;
+		font-family: Go;
 		font-size: 14px;
 		line-height: initial;
 		color: #373a3c;
@@ -108,6 +112,10 @@ func initBlog(issuesService issues.Service, blog issues.RepoSpec, notifications 
 	.post div.reactable-container a:first-child div.new-reaction {
 		display: inline-block;
 	}
+</style>`,
+		HeadPost: `<style type="text/css">
+	.markdown-body { font-family: Go; }
+	tt, code, pre  { font-family: "Go Mono"; }
 </style>`,
 		BodyPre: `{{/* Override create issue button to only show up for shurcooL as New Blog Post button. */}}
 {{define "create-issue"}}

--- a/blog.go
+++ b/blog.go
@@ -25,6 +25,7 @@ var blogHTML = template.Must(template.New("").Parse(`<html>
 		<title>Dmitri Shuralyov - Blog</title>
 		<link href="/icon.png" rel="icon" type="image/png">
 		<meta name="viewport" content="width=device-width">
+		<link href="/assets/fonts/fonts.css" rel="stylesheet" type="text/css">
 		<link href="/blog/assets/gfm/gfm.css" rel="stylesheet" type="text/css">
 		<link href="/assets/blog/style.css" rel="stylesheet" type="text/css">
 		<script async src="/assets/blog/blog.js"></script>
@@ -45,6 +46,7 @@ func initBlog(issuesService issues.Service, blog issues.RepoSpec, notifications 
 		HeadPre: `<title>Dmitri Shuralyov - Blog</title>
 <link href="/icon.png" rel="icon" type="image/png">
 <meta name="viewport" content="width=device-width">
+<link href="/assets/fonts/fonts.css" rel="stylesheet" type="text/css">
 <style type="text/css">
 	body {
 		margin: 20px;

--- a/idiomaticgo.go
+++ b/idiomaticgo.go
@@ -19,6 +19,7 @@ var idiomaticGoHTML = template.Must(template.New("").Parse(`<html>
 		<title>Idiomatic Go</title>
 		<link href="/icon.png" rel="icon" type="image/png">
 		<meta name="viewport" content="width=device-width">
+		<link href="/assets/fonts/fonts.css" rel="stylesheet" type="text/css">
 		<link href="/blog/assets/gfm/gfm.css" rel="stylesheet" type="text/css">
 		<link href="/assets/idiomaticgo/style.css" rel="stylesheet" type="text/css">
 		<script async src="/assets/idiomaticgo/idiomaticgo.js"></script>

--- a/idiomaticgo.go
+++ b/idiomaticgo.go
@@ -21,6 +21,10 @@ var idiomaticGoHTML = template.Must(template.New("").Parse(`<html>
 		<meta name="viewport" content="width=device-width">
 		<link href="/assets/fonts/fonts.css" rel="stylesheet" type="text/css">
 		<link href="/blog/assets/gfm/gfm.css" rel="stylesheet" type="text/css">
+		<style type="text/css">
+			.markdown-body { font-family: Go; }
+			tt, code, pre  { font-family: "Go Mono"; }
+		</style>
 		<link href="/assets/idiomaticgo/style.css" rel="stylesheet" type="text/css">
 		<script async src="/assets/idiomaticgo/idiomaticgo.js"></script>
 		{{if .Production}}` + googleAnalytics + `{{end}}

--- a/index.go
+++ b/index.go
@@ -31,6 +31,7 @@ var indexHTML = template.Must(template.New("").Parse(`<html>
 		<title>Dmitri Shuralyov</title>
 		<link href="/icon.png" rel="icon" type="image/png">
 		<meta name="viewport" content="width=device-width">
+		<link href="/assets/fonts/fonts.css" rel="stylesheet" type="text/css">
 		<link href="/assets/index/style.css" rel="stylesheet" type="text/css">
 		{{if .Production}}` + googleAnalytics + `{{end}}
 	</head>

--- a/issues.go
+++ b/issues.go
@@ -39,6 +39,7 @@ func initIssues(issuesService issues.Service, notifications notifications.Servic
 
 		HeadPre: `<link href="/icon.png" rel="icon" type="image/png">
 <meta name="viewport" content="width=device-width">
+<link href="/assets/fonts/fonts.css" rel="stylesheet" type="text/css">
 <style type="text/css">
 	body {
 		margin: 20px;

--- a/issues.go
+++ b/issues.go
@@ -43,7 +43,7 @@ func initIssues(issuesService issues.Service, notifications notifications.Servic
 <style type="text/css">
 	body {
 		margin: 20px;
-		font-family: sans-serif;
+		font-family: Go;
 		font-size: 14px;
 		line-height: initial;
 		color: #373a3c;
@@ -66,6 +66,10 @@ func initIssues(issuesService issues.Service, notifications notifications.Servic
 		background-color: #fff;
 		box-shadow: 0 1px 1px rgba(0, 0, 0, .05);
 	}
+</style>`,
+		HeadPost: `<style type="text/css">
+	.markdown-body { font-family: Go; }
+	tt, code, pre  { font-family: "Go Mono"; }
 </style>`,
 		BodyPre: `<div style="max-width: 800px; margin: 0 auto 100px auto;">`,
 	}

--- a/main.go
+++ b/main.go
@@ -19,7 +19,6 @@ import (
 	"github.com/shurcooL/httpfs/filter"
 	"github.com/shurcooL/httpgzip"
 	"github.com/shurcooL/issues"
-	"github.com/shurcooL/reactions/emojis"
 	"github.com/shurcooL/users"
 	"golang.org/x/net/webdav"
 )
@@ -41,6 +40,9 @@ func main() {
 
 func run() error {
 	if err := mime.AddExtensionType(".md", "text/markdown"); err != nil {
+		return err
+	}
+	if err := mime.AddExtensionType(".woff2", "application/font-woff"); err != nil {
 		return err
 	}
 
@@ -117,11 +119,14 @@ func run() error {
 		return err
 	}
 
-	emojisHandler := cookieAuth{httpgzip.FileServer(emojis.Assets, httpgzip.FileServerOptions{ServeError: detailedForAdmin{Users: users}.ServeError})}
+	emojisHandler := cookieAuth{httpgzip.FileServer(assets.Emojis, httpgzip.FileServerOptions{ServeError: detailedForAdmin{Users: users}.ServeError})}
 	http.Handle("/emojis/", http۰StripPrefix("/emojis", emojisHandler))
 
 	assetsHandler := cookieAuth{httpgzip.FileServer(assets.Assets, httpgzip.FileServerOptions{ServeError: detailedForAdmin{Users: users}.ServeError})}
 	http.Handle("/assets/", assetsHandler)
+
+	fontsHandler := cookieAuth{httpgzip.FileServer(assets.Fonts, httpgzip.FileServerOptions{ServeError: detailedForAdmin{Users: users}.ServeError})}
+	http.Handle("/assets/fonts/", http۰StripPrefix("/assets/fonts", fontsHandler))
 
 	initResume(assetsHandler, reactions, notifications, users)
 

--- a/notifications.go
+++ b/notifications.go
@@ -62,6 +62,7 @@ func initNotifications(mux *http.ServeMux, root webdav.FileSystem, users users.S
 		HeadPre: `<title>Notifications</title>
 <link href="/icon.png" rel="icon" type="image/png">
 <meta name="viewport" content="width=device-width">
+<link href="/assets/fonts/fonts.css" rel="stylesheet" type="text/css">
 <style type="text/css">
 	body {
 		margin: 20px;

--- a/notifications.go
+++ b/notifications.go
@@ -68,7 +68,7 @@ func initNotifications(mux *http.ServeMux, root webdav.FileSystem, users users.S
 		margin: 20px;
 	}
 	body, table {
-		font-family: sans-serif;
+		font-family: Go;
 		font-size: 14px;
 		line-height: initial;
 		color: #373a3c;

--- a/packages.go
+++ b/packages.go
@@ -23,6 +23,7 @@ var packagesHTML = template.Must(template.New("").Parse(`<html>
 		<title>Packages</title>
 		<link href="/icon.png" rel="icon" type="image/png">
 		<meta name="viewport" content="width=device-width">
+		<link href="/assets/fonts/fonts.css" rel="stylesheet" type="text/css">
 		<link href="/assets/packages/style.css" rel="stylesheet" type="text/css">
 		{{if .Production}}` + googleAnalytics + `{{end}}
 	</head>

--- a/projects.go
+++ b/projects.go
@@ -26,6 +26,7 @@ var projectsHTML = template.Must(template.New("").Parse(`<html>
 		<title>Dmitri Shuralyov - Projects</title>
 		<link href="/icon.png" rel="icon" type="image/png">
 		<meta name="viewport" content="width=device-width">
+		<link href="/assets/fonts/fonts.css" rel="stylesheet" type="text/css">
 		<link href="/assets/projects/style.css" rel="stylesheet" type="text/css">
 		{{if .Production}}` + googleAnalytics + `{{end}}
 	</head>

--- a/resume.go
+++ b/resume.go
@@ -20,6 +20,7 @@ var resumeHTML = template.Must(template.New("").Funcs(template.FuncMap{"noescape
 		<title>Dmitri Shuralyov - Resume</title>
 		<link href="/icon.png" rel="icon" type="image/png">
 		<meta name="viewport" content="width=device-width">
+		<link href="/assets/fonts/fonts.css" rel="stylesheet" type="text/css">
 		<link href="/resume.css" rel="stylesheet" type="text/css">
 
 		{{noescape "<!-- Unminified source is at https://github.com/shurcooL/resume. -->"}}

--- a/talks.go
+++ b/talks.go
@@ -29,6 +29,7 @@ var talksHTML = template.Must(template.New("").Parse(`<html>
 		<title>Dmitri Shuralyov - Talks</title>
 		<link href="/icon.png" rel="icon" type="image/png">
 		<meta name="viewport" content="width=device-width">
+		<link href="/assets/fonts/fonts.css" rel="stylesheet" type="text/css">
 		<link href="/assets/talks/style.css" rel="stylesheet" type="text/css">
 		{{if .Production}}` + googleAnalytics + `{{end}}
 	</head>


### PR DESCRIPTION
### History

Previously, the two main fonts were `sans-serif` and `monospace` on most pages. These are simple and look fine, but they're not consistent across multiple platforms.

The following font combinations were used on some other pages:

- "Helvetica Neue", Helvetica, "Segoe UI", Arial, freesans, sans-serif.
- "Helvetica Neue", Helvetica, Arial, sans-serif;
- Arial, Helvetica, sans-serif;
- Verdana, Geneva, sans-serif;
- Consolas, "Liberation Mono", Menlo, Courier, monospace.

Some of those look better (e.g., Menlo is much nicer compared to `monospace`), but they're also not consistent across multiple platforms, and some of them are not freely licenced.

## Motivation

Using Go font family enables a simple, consistent, and more unique look and feel across all platforms (macOS, Linux, Windows, iOS, Android). It also reduces the number of proprietary dependencies that are relied on, making the website more self-contained.

Using the Go font family feels a bit like `gofmt`, in that the exact formatting nuances of gofmt are no one's favorite, but the convention of using gofmt is everyone's favorite.

### Before

![image](https://user-images.githubusercontent.com/1924134/28732228-1b8f1638-73a5-11e7-92ce-ad7d34f12b2d.png)

![image](https://user-images.githubusercontent.com/1924134/28732232-207174fc-73a5-11e7-919b-9f0e19c7ace1.png)

![image](https://user-images.githubusercontent.com/1924134/28732234-259b7572-73a5-11e7-8e64-dda6b7962168.png)

### After

![image](https://user-images.githubusercontent.com/1924134/28732244-2aa7c282-73a5-11e7-9478-dbacdc0768af.png)

![image](https://user-images.githubusercontent.com/1924134/28732248-2f0e017e-73a5-11e7-90b9-59163bd6c383.png)

![image](https://user-images.githubusercontent.com/1924134/28732257-3408d050-73a5-11e7-99f0-4612fc7ba46f.png)