### PR TITLE
Add change tracking service and changes app.

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"dmitri.shuralyov.com/app/changes"
+	"dmitri.shuralyov.com/app/changes/common"
+	"dmitri.shuralyov.com/service/change/githubapi"
+	"github.com/google/go-github/github"
+	"github.com/gregjones/httpcache"
+	"github.com/shurcooL/githubql"
+	"github.com/shurcooL/home/component"
+	"github.com/shurcooL/home/httputil"
+	"github.com/shurcooL/htmlg"
+	"github.com/shurcooL/httperror"
+	"github.com/shurcooL/notifications"
+	"github.com/shurcooL/octiconssvg"
+	"github.com/shurcooL/users"
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
+	"golang.org/x/oauth2"
+)
+
+// initChanges registers handlers for the changes service HTTP API,
+// and handlers for the changes app.
+func initChanges(mux *http.ServeMux, notifications notifications.Service, users users.Service) error {
+	authTransport := &oauth2.Transport{
+		Source: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: os.Getenv("HOME_GH_SHURCOOL_ISSUES")}),
+	}
+	cacheTransport := &httpcache.Transport{
+		Transport:           authTransport,
+		Cache:               httpcache.NewMemoryCache(),
+		MarkCachedResponses: true,
+	}
+	httpClient := &http.Client{Transport: cacheTransport, Timeout: 5 * time.Second}
+	change, err := githubapi.NewService(
+		github.NewClient(httpClient),
+		githubql.NewClient(httpClient),
+		notifications,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Register HTTP API endpoints.
+	// ...
+
+	opt := changes.Options{
+		Notifications: notifications,
+
+		HeadPre: `<link href="/icon.png" rel="icon" type="image/png">
+<meta name="viewport" content="width=device-width">
+<link href="/assets/fonts/fonts.css" rel="stylesheet" type="text/css">
+<style type="text/css">
+	body {
+		margin: 20px;
+		font-family: Go;
+		font-size: 14px;
+		line-height: initial;
+		color: rgb(35, 35, 35);
+	}
+	a {
+		color: #4183c4;
+		text-decoration: none;
+	}
+	a:hover {
+		text-decoration: underline;
+	}
+	a.gray {
+		color: #bbb;
+	}
+	a.gray:hover {
+		color: black;
+	}
+	.btn {
+		font-family: inherit;
+		font-size: 11px;
+		line-height: 11px;
+		height: 18px;
+		border-radius: 4px;
+		border: solid #d2d2d2 1px;
+		background-color: #fff;
+		box-shadow: 0 1px 1px rgba(0, 0, 0, .05);
+	}
+
+	/* https://github.com/primer/primer-navigation */
+	.counter{display:inline-block;padding:2px 5px;font-size:12px;font-weight:600;line-height:1;color:#666;background-color:#eee;border-radius:20px}.menu{margin-bottom:15px;list-style:none;background-color:#fff;border:1px solid #d8d8d8;border-radius:3px}.menu-item{position:relative;display:block;padding:8px 10px;border-bottom:1px solid #eee}.menu-item:first-child{border-top:0;border-top-left-radius:2px;border-top-right-radius:2px}.menu-item:first-child::before{border-top-left-radius:2px}.menu-item:last-child{border-bottom:0;border-bottom-right-radius:2px;border-bottom-left-radius:2px}.menu-item:last-child::before{border-bottom-left-radius:2px}.menu-item:hover{text-decoration:none;background-color:#f9f9f9}.menu-item.selected{font-weight:bold;color:#222;cursor:default;background-color:#fff}.menu-item.selected::before{position:absolute;top:0;bottom:0;left:0;width:2px;content:"";background-color:#d26911}.menu-item .octicon{width:16px;margin-right:5px;color:#333;text-align:center}.menu-item .counter{float:right;margin-left:5px}.menu-item .menu-warning{float:right;color:#d26911}.menu-item .avatar{float:left;margin-right:5px}.menu-item.alert .counter{color:#bd2c00}.menu-heading{display:block;padding:8px 10px;margin-top:0;margin-bottom:0;font-size:13px;font-weight:bold;line-height:20px;color:#555;background-color:#f7f7f7;border-bottom:1px solid #eee}.menu-heading:hover{text-decoration:none}.menu-heading:first-child{border-top-left-radius:2px;border-top-right-radius:2px}.menu-heading:last-child{border-bottom:0;border-bottom-right-radius:2px;border-bottom-left-radius:2px}.tabnav{margin-top:0;margin-bottom:15px;border-bottom:1px solid #ddd}.tabnav .counter{margin-left:5px}.tabnav-tabs{margin-bottom:-1px}.tabnav-tab{display:inline-block;padding:8px 12px;font-size:14px;line-height:20px;color:#666;text-decoration:none;background-color:transparent;border:1px solid transparent;border-bottom:0}.tabnav-tab.selected{color:#333;background-color:#fff;border-color:#ddd;border-radius:3px 3px 0 0}.tabnav-tab:hover,.tabnav-tab:focus{text-decoration:none}.tabnav-extra{display:inline-block;padding-top:10px;margin-left:10px;font-size:12px;color:#666}.tabnav-extra>.octicon{margin-right:2px}a.tabnav-extra:hover{color:#4078c0;text-decoration:none}.tabnav-btn{margin-left:10px}.filter-list{list-style-type:none}.filter-list.small .filter-item{padding:4px 10px;margin:0 0 2px;font-size:12px}.filter-list.pjax-active .filter-item{color:#767676;background-color:transparent}.filter-list.pjax-active .filter-item.pjax-active{color:#fff;background-color:#4078c0}.filter-item{position:relative;display:block;padding:8px 10px;margin-bottom:5px;overflow:hidden;font-size:14px;color:#767676;text-decoration:none;text-overflow:ellipsis;white-space:nowrap;cursor:pointer;border-radius:3px}.filter-item:hover{text-decoration:none;background-color:#eee}.filter-item.selected{color:#fff;background-color:#4078c0}.filter-item .count{float:right;font-weight:bold}.filter-item .bar{position:absolute;top:2px;right:0;bottom:2px;z-index:-1;display:inline-block;background-color:#f1f1f1}.subnav{margin-bottom:20px}.subnav::before{display:table;content:""}.subnav::after{display:table;clear:both;content:""}.subnav-bordered{padding-bottom:20px;border-bottom:1px solid #eee}.subnav-flush{margin-bottom:0}.subnav-item{position:relative;float:left;padding:6px 14px;font-weight:600;line-height:20px;color:#666;border:1px solid #e5e5e5}.subnav-item+.subnav-item{margin-left:-1px}.subnav-item:hover,.subnav-item:focus{text-decoration:none;background-color:#f5f5f5}.subnav-item.selected,.subnav-item.selected:hover,.subnav-item.selected:focus{z-index:2;color:#fff;background-color:#4078c0;border-color:#4078c0}.subnav-item:first-child{border-top-left-radius:3px;border-bottom-left-radius:3px}.subnav-item:last-child{border-top-right-radius:3px;border-bottom-right-radius:3px}.subnav-search{position:relative;margin-left:10px}.subnav-search-input{width:320px;padding-left:30px;color:#767676;border-color:#d5d5d5}.subnav-search-input-wide{width:500px}.subnav-search-icon{position:absolute;top:9px;left:8px;display:block;color:#ccc;text-align:center;pointer-events:none}.subnav-search-context .btn{color:#555;border-top-right-radius:0;border-bottom-right-radius:0}.subnav-search-context .btn:hover,.subnav-search-context .btn:focus,.subnav-search-context .btn:active,.subnav-search-context .btn.selected{z-index:2}.subnav-search-context+.subnav-search{margin-left:-1px}.subnav-search-context+.subnav-search .subnav-search-input{border-top-left-radius:0;border-bottom-left-radius:0}.subnav-search-context .select-menu-modal-holder{z-index:30}.subnav-search-context .select-menu-modal{width:220px}.subnav-search-context .select-menu-item-icon{color:inherit}.subnav-spacer-right{padding-right:10px}
+</style>`,
+		// TODO: The primer-navigation CSS above ends up being included twice; here and in changes/style.css. Deduplicate it somehow...
+		HeadPost: `<style type="text/css">
+	.markdown-body { font-family: Go; }
+	tt, code, pre  { font-family: "Go Mono"; }
+</style>`,
+		BodyPre: `<div style="max-width: 800px; margin: 0 auto 100px auto;">`,
+	}
+	if *productionFlag {
+		opt.HeadPre += "\n\t\t" + googleAnalytics
+	}
+	opt.BodyTop = func(req *http.Request, st common.State) ([]htmlg.Component, error) {
+		authenticatedUser, err := users.GetAuthenticated(req.Context())
+		if err != nil {
+			return nil, err
+		}
+		var nc uint64
+		if authenticatedUser.ID != 0 {
+			nc, err = notifications.Count(req.Context(), nil)
+			if err != nil {
+				return nil, err
+			}
+		}
+		returnURL := req.RequestURI
+
+		header := component.Header{
+			CurrentUser:       authenticatedUser,
+			NotificationCount: nc,
+			ReturnURL:         returnURL,
+		}
+
+		switch repoSpec := req.Context().Value(changes.RepoSpecContextKey).(string); {
+		default:
+			return []htmlg.Component{header}, nil
+
+		// TODO: Dedup with issues (maybe; mind the githubURL difference).
+		case strings.HasPrefix(repoSpec, "github.com/"):
+			heading := &html.Node{
+				Type: html.ElementNode, Data: atom.H2.String(),
+			}
+			heading.AppendChild(htmlg.Text(repoSpec))
+			var githubURL string
+			switch st.ChangeID {
+			case 0:
+				githubURL = fmt.Sprintf("https://%s/pulls", repoSpec)
+			default:
+				githubURL = fmt.Sprintf("https://%s/pull/%d", repoSpec, st.ChangeID)
+			}
+			heading.AppendChild(&html.Node{
+				Type: html.ElementNode, Data: atom.A.String(),
+				Attr: []html.Attribute{
+					{Key: atom.Href.String(), Val: githubURL},
+					{Key: atom.Class.String(), Val: "gray"},
+					{Key: atom.Style.String(), Val: "margin-left: 10px;"},
+				},
+				FirstChild: octiconssvg.SetSize(octiconssvg.MarkGitHub(), 24),
+			})
+			tabnav := tabnav{
+				Tabs: []tab{
+					{
+						Content: iconText{Icon: octiconssvg.IssueOpened, Text: "Issues"},
+						URL:     "/issues/" + repoSpec,
+					},
+					{
+						Content:  iconText{Icon: octiconssvg.GitPullRequest, Text: "Changes"},
+						URL:      "/changes/" + repoSpec,
+						Selected: true,
+					},
+				},
+			}
+			return []htmlg.Component{header, htmlg.NodeComponent(*heading), tabnav}, nil
+		}
+	}
+	changesApp := changes.New(change, users, opt)
+
+	githubChangesHandler := cookieAuth{httputil.ErrorHandler(users, func(w http.ResponseWriter, req *http.Request) error {
+		// Parse "/changes/github.com/..." request.
+		elems := strings.SplitN(req.URL.Path[len("/changes/github.com/"):], "/", 3)
+		if len(elems) < 2 || elems[0] == "" || elems[1] == "" {
+			return os.ErrNotExist
+		}
+		currentUser, err := users.GetAuthenticatedSpec(req.Context())
+		if err != nil {
+			return err
+		}
+		if currentUser != shurcool {
+			// Redirect to GitHub.
+			switch len(elems) {
+			case 2:
+				return httperror.Redirect{URL: "https://github.com/" + elems[0] + "/" + elems[1] + "/pulls"}
+			default: // 3 or more.
+				return httperror.Redirect{URL: "https://github.com/" + elems[0] + "/" + elems[1] + "/pull/" + elems[2]}
+			}
+		}
+		specURL := "github.com/" + elems[0] + "/" + elems[1]
+		baseURL := "/changes/" + specURL
+
+		prefixLen := len(baseURL)
+		if prefix := req.URL.Path[:prefixLen]; req.URL.Path == prefix+"/" {
+			baseURL := prefix
+			if req.URL.RawQuery != "" {
+				baseURL += "?" + req.URL.RawQuery
+			}
+			return httperror.Redirect{URL: baseURL}
+		}
+		returnURL := req.RequestURI
+		req = copyRequestAndURL(req)
+		req.URL.Path = req.URL.Path[prefixLen:]
+		if req.URL.Path == "" {
+			req.URL.Path = "/"
+		}
+		rr := httptest.NewRecorder()
+		rr.HeaderMap = w.Header()
+		req = req.WithContext(context.WithValue(req.Context(), changes.RepoSpecContextKey, specURL))
+		req = req.WithContext(context.WithValue(req.Context(), changes.BaseURIContextKey, baseURL))
+		changesApp.ServeHTTP(rr, req)
+		// TODO: Have changesApp.ServeHTTP return error, check if os.IsPermission(err) is true, etc.
+		// TODO: Factor out this os.IsPermission(err) && u == nil check somewhere, if possible. (But this shouldn't apply for APIs.)
+		if s := req.Context().Value(sessionContextKey).(*session); rr.Code == http.StatusForbidden && s == nil {
+			loginURL := (&url.URL{
+				Path:     "/login",
+				RawQuery: url.Values{returnQueryName: {returnURL}}.Encode(),
+			}).String()
+			return httperror.Redirect{URL: loginURL}
+		}
+		w.WriteHeader(rr.Code)
+		_, err = io.Copy(w, rr.Body)
+		return err
+	})}
+	mux.Handle("/changes/github.com/", githubChangesHandler)
+
+	return nil
+}

--- a/commits.go
+++ b/commits.go
@@ -123,6 +123,10 @@ func (h *commitsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) err
 				Content: iconText{Icon: octiconssvg.IssueOpened, Text: "Issues"},
 				URL:     route.RepoIssues(h.Repo.Path),
 			},
+			{
+				Content: iconText{Icon: octiconssvg.GitPullRequest, Text: "Changes"},
+				URL:     route.RepoChanges(h.Repo.Path),
+			},
 		},
 	})
 	if err != nil {

--- a/index.go
+++ b/index.go
@@ -224,15 +224,15 @@ func (a activity) Render() []*html.Node {
 			}
 			e.Details = details
 			displayEvent = e
-		case event.PullRequest:
+		case event.Change:
 			e := activityEvent{
 				basicEvent: &basicEvent,
 				Icon:       octiconssvg.GitPullRequest,
-				Action:     component.Text(fmt.Sprintf("%v a pull request in", p.Action)),
+				Action:     component.Text(fmt.Sprintf("%v a change in", p.Action)),
 			}
 			details := iconLink{
-				Text:  p.PullRequestTitle,
-				URL:   p.PullRequestHTMLURL,
+				Text:  p.ChangeTitle,
+				URL:   p.ChangeHTMLURL,
 				Black: true,
 			}
 			switch p.Action {
@@ -247,7 +247,7 @@ func (a activity) Render() []*html.Node {
 				details.IconColor = &RGB{R: 0x6e, G: 0x54, B: 0x94} // Purple.
 
 				//default:
-				//log.Println("activity.Render: unsupported event.PullRequest action:", p.Action)
+				//log.Println("activity.Render: unsupported event.Change action:", p.Action)
 				//details.Icon = octiconssvg.GitPullRequest
 			}
 			e.Details = details
@@ -263,11 +263,11 @@ func (a activity) Render() []*html.Node {
 					Text:     shortBody(p.CommentBody),
 				},
 			}
-		case event.PullRequestComment:
+		case event.ChangeComment:
 			displayEvent = activityEvent{
 				basicEvent: &basicEvent,
 				Icon:       octiconssvg.CommentDiscussion,
-				Action:     component.Join("commented on ", prName(p), " in"),
+				Action:     component.Join("commented on ", changeName(p), " in"),
 				Details: imageText{
 					ImageURL: e.Actor.AvatarURL,
 					Text:     shortBody(p.CommentBody),
@@ -404,13 +404,13 @@ func issueName(p event.IssueComment) htmlg.Component {
 	}
 	return n
 }
-func prName(p event.PullRequestComment) htmlg.Component {
+func changeName(p event.ChangeComment) htmlg.Component {
 	n := iconLink{
-		Text:    shortTitle(p.PullRequestTitle),
-		Tooltip: p.PullRequestTitle,
+		Text:    shortTitle(p.ChangeTitle),
+		Tooltip: p.ChangeTitle,
 		URL:     p.CommentHTMLURL,
 	}
-	switch p.PullRequestState {
+	switch p.ChangeState {
 	case "open":
 		n.Icon = octiconssvg.GitPullRequest
 		n.IconColor = &RGB{R: 0x6c, G: 0xc6, B: 0x44} // Green.
@@ -422,7 +422,7 @@ func prName(p event.PullRequestComment) htmlg.Component {
 		n.IconColor = &RGB{R: 0x6e, G: 0x54, B: 0x94} // Purple.
 
 		//default:
-		//log.Println("prName: unsupported event.PullRequestComment State:", p.State)
+		//log.Println("changeName: unsupported event.ChangeComment State:", p.State)
 		//n.Icon = octiconssvg.GitPullRequest
 	}
 	return n

--- a/internal/route/route.go
+++ b/internal/route/route.go
@@ -25,3 +25,4 @@ func RepoIndex(repoPath string) string   { return repoPath + "/..." }
 func RepoHistory(repoPath string) string { return repoPath + "/...$history" }
 func RepoCommit(repoPath string) string  { return repoPath + "/...$commit" }
 func RepoIssues(repoPath string) string  { return repoPath + "/...$issues" }
+func RepoChanges(repoPath string) string { return repoPath + "/...$changes" }

--- a/issues.go
+++ b/issues.go
@@ -174,6 +174,10 @@ func initIssues(mux *http.ServeMux, issuesService issues.Service, notifications 
 						URL:      route.RepoIssues(repoPath),
 						Selected: true,
 					},
+					{
+						Content: iconText{Icon: octiconssvg.GitPullRequest, Text: "Changes"},
+						URL:     route.RepoChanges(repoPath),
+					},
 				},
 			}
 			return []htmlg.Component{header, heading, tabnav}, nil

--- a/main.go
+++ b/main.go
@@ -125,7 +125,7 @@ func run() error {
 		return err
 	}
 
-	err = initChanges(http.DefaultServeMux, notifications, users)
+	changesApp, err := initChanges(http.DefaultServeMux, notifications, users)
 	if err != nil {
 		return err
 	}
@@ -157,7 +157,7 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	codeHandler := codeHandler{code, reposDir, issuesApp, notifications, users, gitUsers}
+	codeHandler := codeHandler{code, reposDir, issuesApp, changesApp, notifications, users, gitUsers}
 	servePackagesMaybe := initPackages(code, notifications, users)
 
 	initTalks(

--- a/main.go
+++ b/main.go
@@ -125,6 +125,11 @@ func run() error {
 		return err
 	}
 
+	err = initChanges(http.DefaultServeMux, notifications, users)
+	if err != nil {
+		return err
+	}
+
 	emojisHandler := cookieAuth{httpgzip.FileServer(assets.Emojis, httpgzip.FileServerOptions{ServeError: detailedForAdmin{Users: users}.ServeError})}
 	http.Handle("/emojis/", http۰StripPrefix("/emojis", emojisHandler))
 

--- a/package.go
+++ b/package.go
@@ -113,6 +113,10 @@ func (h *packageHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) err
 				Content: iconText{Icon: octiconssvg.IssueOpened, Text: "Issues"},
 				URL:     route.RepoIssues(h.Repo.Path),
 			},
+			{
+				Content: iconText{Icon: octiconssvg.GitPullRequest, Text: "Changes"},
+				URL:     route.RepoChanges(h.Repo.Path),
+			},
 		},
 	})
 	if err != nil {

--- a/repository.go
+++ b/repository.go
@@ -109,6 +109,10 @@ func (h *repositoryHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) 
 				Content: iconText{Icon: octiconssvg.IssueOpened, Text: "Issues"},
 				URL:     route.RepoIssues(h.Repo.Path),
 			},
+			{
+				Content: iconText{Icon: octiconssvg.GitPullRequest, Text: "Changes"},
+				URL:     route.RepoChanges(h.Repo.Path),
+			},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
This PR adds a change tracking service and changes app. It is used for displaying PRs on GitHub (for @shurcooL user only), and for displaying local changes in local repositories (for everyone).

This is an initial version, it is not yet complete. The service and app are completely read-only at this time. Write capabilities will come in future changes.

### Screenshots

![image](https://user-images.githubusercontent.com/1924134/36080955-208954fc-0f66-11e8-9fb1-e134df5fa542.png)

![image](https://user-images.githubusercontent.com/1924134/36080957-36aec5dc-0f66-11e8-9afa-dfef6554748a.png)

![image](https://user-images.githubusercontent.com/1924134/36080961-3f3f6f30-0f66-11e8-8885-84862f13e209.png)

![image](https://user-images.githubusercontent.com/1924134/36080963-45ff8e9a-0f66-11e8-995e-209923382679.png)

![image](https://user-images.githubusercontent.com/1924134/36080964-4e330934-0f66-11e8-8d1e-727fecf2f189.png)
