### PR TITLE
internal/code: implement module proxy protocol

### DIFF
--- a/code.go
+++ b/code.go
@@ -72,7 +72,8 @@ func (h *codeHandler) ServeCodeMaybe(w http.ResponseWriter, req *http.Request) (
 		if req.Method == http.MethodGet && req.URL.Query().Get("go-get") == "1" {
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			fmt.Fprintf(w, `<meta name="go-import" content="%[1]s git https://%[1]s">
-	<meta name="go-source" content="%[1]s https://%[1]s https://gotools.org/%[2]s https://gotools.org/%[2]s#{file}-L{line}">`, d.RepoRoot, d.ImportPath)
+<meta name="go-import" content="%[1]s mod https://">
+<meta name="go-source" content="%[1]s https://%[1]s https://gotools.org/%[2]s https://gotools.org/%[2]s#{file}-L{line}">`, d.RepoRoot, d.ImportPath)
 			return true
 		}
 

--- a/internal/code/code_test.go
+++ b/internal/code/code_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/shurcooL/users"
 )
 
-func Test(t *testing.T) {
+func TestCode(t *testing.T) {
 	tempDir, err := ioutil.TempDir("", "code_test_")
 	if err != nil {
 		t.Fatal(err)
@@ -42,6 +42,7 @@ func Test(t *testing.T) {
 		t.Fatal("code.NewService:", err)
 	}
 
+	// Create a real HTTP server so we can git push to it.
 	gitHandler, err := code.NewGitHandler(service, filepath.Join(tempDir, "repositories"), events, users, nil, func(req *http.Request) *http.Request { return req })
 	if err != nil {
 		t.Fatal("code.NewGitHandler:", err)
@@ -50,7 +51,7 @@ func Test(t *testing.T) {
 		if ok := gitHandler.ServeGitMaybe(w, req); ok {
 			return
 		}
-		t.Error("http server got a non-git request")
+		t.Error("HTTP server got a non-git request")
 		http.NotFound(w, req)
 	}))
 	defer httpServer.Close()

--- a/internal/code/module.go
+++ b/internal/code/module.go
@@ -1,0 +1,325 @@
+package code
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/rogpeppe/go-internal/modfile"
+	"github.com/rogpeppe/go-internal/module"
+	"github.com/shurcooL/go/vfs/godocfs/vfsutil"
+	"github.com/shurcooL/home/internal/mod"
+	"github.com/shurcooL/httperror"
+	"golang.org/x/tools/godoc/vfs"
+	"sourcegraph.com/sourcegraph/go-vcs/vcs/git"
+)
+
+// ModuleHandler is a Go module server that implements the
+// module proxy protocol. It serves each repository root
+// available in Code as a Go module.
+//
+// At this time, it has various limitations compared to the
+// general go mod download functionality that extracts module
+// versions from a VCS repository:
+//
+// 	•	Versions served include only pseudo-versions from
+// 		commits on master branch. Tags and other branches
+// 		are not supported at this time.
+// 	•	Multi-module repositories are not supported at this time.
+//
+// This may change over time as my needs evolve.
+type ModuleHandler struct {
+	Code *Service
+}
+
+// ServeModuleMaybe serves a module proxy protocol HTTP request, if it matches.
+// It returns httperror.NotHandle if the HTTP request was explicitly not handled.
+func (h ModuleHandler) ServeModuleMaybe(w http.ResponseWriter, req *http.Request) error {
+	if req.Method != http.MethodGet {
+		return httperror.NotHandle
+	}
+
+	// Parse the module path, type, and version from the URL.
+	r, ok := parseModuleProxyRequest("dmitri.shuralyov.com" + req.URL.Path)
+	if !ok {
+		return httperror.NotHandle
+	}
+	dec, ok := r.Decode() // Decode module path and version.
+	if !ok {
+		// Maybe it was an unencoded module path or version (e.g., from a human visitor).
+		// Check if they can both be successfully encoded. If so, redirect to that URL.
+		if enc, ok := r.Encode(); ok {
+			// Preserve the current scheme and host.
+			u, err := url.Parse("https://" + enc.URL())
+			if err != nil {
+				return fmt.Errorf("ModuleHandler.ServeModuleMaybe: failed to parse own redirect URL: %v", err)
+			}
+			return httperror.Redirect{URL: u.Path}
+		}
+		return httperror.NotHandle
+	}
+	modulePath, typ, version := dec.Module, dec.Type, dec.Version
+
+	// Look up code directory by module path.
+	d, ok := h.Code.Lookup(modulePath)
+	if !ok || !d.IsRepoRoot() {
+		return httperror.NotHandle
+	}
+	gitDir := filepath.Join(h.Code.reposDir, filepath.FromSlash(d.RepoRoot))
+
+	// Handle "/@v/list" request.
+	if typ == "list" {
+		revs, err := listMasterCommits(req.Context(), gitDir)
+		if err != nil {
+			return err
+		}
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		for i := len(revs) - 1; i >= 0; i-- {
+			fmt.Fprintln(w, revs[i].Version)
+		}
+		return nil
+	}
+
+	// Parse the time and revision from the pseudo-version.
+	versionTime, versionRevision, err := mod.ParsePseudoVersion(version)
+	if err != nil || len(versionRevision) != 12 || !mod.AllHex(versionRevision) {
+		return os.ErrNotExist
+	}
+
+	// Open the git repository and get the commit that corresponds to the pseudo-version.
+	repo, err := git.Open(gitDir)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := repo.Close(); err != nil {
+			log.Println("ModuleHandler.ServeModuleMaybe: repo.Close:", err)
+		}
+	}()
+	commitID, err := repo.ResolveRevision(versionRevision)
+	if err != nil {
+		return os.ErrNotExist
+	}
+	commit, err := repo.GetCommit(commitID)
+	if err != nil || commit.Committer == nil || !versionTime.Equal(time.Unix(commit.Committer.Date.Seconds, 0).UTC()) {
+		return os.ErrNotExist
+	}
+
+	// Handle one of "/@v/<version>.<ext>" requests.
+	switch typ {
+	case "info":
+		w.Header().Set("Content-Type", "application/json")
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "\t")
+		err := enc.Encode(mod.RevInfo{
+			Version: version,
+			Time:    versionTime,
+		})
+		return err
+	case "mod":
+		fs, err := repo.FileSystem(commitID)
+		if err != nil {
+			return err
+		}
+		f, err := fs.Open("/go.mod")
+		if os.IsNotExist(err) {
+			// go.mod file doesn't exist in this commit.
+			f = nil
+		} else if err != nil {
+			return err
+		}
+		if f != nil {
+			defer f.Close()
+		}
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		if f != nil {
+			// Copy the existing go.mod file.
+			_, err := io.Copy(w, f)
+			return err
+		} else {
+			// Synthesize a go.mod file with just the module path.
+			_, err := fmt.Fprintf(w, "module %s\n", modfile.AutoQuote(modulePath))
+			return err
+		}
+	case "zip":
+		fs, err := repo.FileSystem(commitID)
+		if err != nil {
+			return err
+		}
+		w.Header().Set("Content-Type", "application/zip")
+		z := zip.NewWriter(w)
+		err = vfsutil.Walk(fs, "/", func(name string, fi os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if fi.IsDir() {
+				// We only care about files.
+				return nil
+			}
+			b, err := vfs.ReadFile(fs, name)
+			if err != nil {
+				return err
+			}
+			f, err := z.Create(modulePath + "@" + version + name)
+			if err != nil {
+				return err
+			}
+			_, err = f.Write(b)
+			return err
+		})
+		if err != nil {
+			return err
+		}
+		err = z.Close()
+		return err
+	default:
+		return os.ErrNotExist
+	}
+}
+
+// listMasterCommits returns a list of commits in git repo on master branch.
+// If master branch doesn't exist, an empty list is returned.
+func listMasterCommits(ctx context.Context, gitDir string) ([]mod.RevInfo, error) {
+	cmd := exec.CommandContext(ctx, "git", "log",
+		"--format=tformat:%H%x00%ct",
+		"-z",
+		"master")
+	cmd.Dir = gitDir
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	err := cmd.Start()
+	if err != nil {
+		return nil, fmt.Errorf("could not start command: %v", err)
+	}
+	err = cmd.Wait()
+	if ee, _ := err.(*exec.ExitError); ee != nil && ee.Sys().(syscall.WaitStatus).ExitStatus() == 128 {
+		return nil, nil // Master branch doesn't exist.
+	} else if err != nil {
+		return nil, fmt.Errorf("%v: %v", cmd.Args, err)
+	}
+
+	var revs []mod.RevInfo
+	for b := buf.Bytes(); len(b) != 0; {
+		var (
+			// Calls to readLine match exactly what is specified in --format.
+			commitHash    = readLine(&b)
+			committerDate = readLine(&b)
+		)
+		timestamp, err := strconv.ParseInt(committerDate, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid time from git log: %v", err)
+		}
+		t := time.Unix(timestamp, 0).UTC()
+		revs = append(revs, mod.RevInfo{
+			Version: mod.PseudoVersion("", "", t, commitHash[:12]),
+			Time:    t,
+		})
+	}
+	return revs, nil
+}
+
+// readLine reads a line until zero byte, then updates b to the byte that immediately follows.
+// A zero byte must exist in b, otherwise readLine panics.
+func readLine(b *[]byte) string {
+	i := bytes.IndexByte(*b, 0)
+	s := string((*b)[:i])
+	*b = (*b)[i+1:]
+	return s
+}
+
+// moduleProxyRequest represents a module proxy request.
+// The Module and Version fields may be encoded or unencoded.
+type moduleProxyRequest struct {
+	Module  string // Module path.
+	Type    string // Type of request. One of "list", "info", "mod", or "zip".
+	Version string // Module version. Applies only when Type is not "list".
+}
+
+// parseModuleProxyRequest parses the module proxy request
+// from the given URL. It does not attempt to decode the
+// module path and version, the caller is responsible for that.
+func parseModuleProxyRequest(url string) (_ moduleProxyRequest, ok bool) {
+	// Split "<module>/@v/<file>" into module and file.
+	i := strings.Index(url, "/@v/")
+	if i == -1 {
+		return moduleProxyRequest{}, false
+	}
+	module, file := url[:i], url[i+len("/@v/"):]
+
+	// Return early for "/@v/list" request. It has no Version.
+	if file == "list" {
+		return moduleProxyRequest{Module: module, Type: "list"}, true
+	}
+
+	// Split "/@v/<version>.<ext>" into version and ext.
+	i = strings.LastIndexByte(file, '.')
+	if i == -1 {
+		return moduleProxyRequest{}, false
+	}
+	version, ext := file[:i], file[i+1:]
+
+	// Check that ext is valid.
+	switch ext {
+	case "info", "mod", "zip":
+		return moduleProxyRequest{Module: module, Type: ext, Version: version}, true
+	default:
+		return moduleProxyRequest{}, false
+	}
+}
+
+// Decode returns a copy of r with Module and Version fields decoded.
+func (r moduleProxyRequest) Decode() (_ moduleProxyRequest, ok bool) {
+	var err error
+	r.Module, err = module.DecodePath(r.Module)
+	if err != nil {
+		return moduleProxyRequest{}, false
+	}
+	if r.Type == "list" {
+		return r, true
+	}
+	r.Version, err = module.DecodeVersion(r.Version)
+	if err != nil {
+		return moduleProxyRequest{}, false
+	}
+	return r, true
+}
+
+// Encode returns a copy of r with Module and Version fields encoded.
+func (r moduleProxyRequest) Encode() (_ moduleProxyRequest, ok bool) {
+	var err error
+	r.Module, err = module.EncodePath(r.Module)
+	if err != nil {
+		return moduleProxyRequest{}, false
+	}
+	if r.Type == "list" {
+		return r, true
+	}
+	r.Version, err = module.EncodeVersion(r.Version)
+	if err != nil {
+		return moduleProxyRequest{}, false
+	}
+	return r, true
+}
+
+// URL returns the URL of the module proxy request.
+func (r moduleProxyRequest) URL() string {
+	switch r.Type {
+	case "list":
+		return r.Module + "/@v/list"
+	default:
+		return r.Module + "/@v/" + r.Version + "." + r.Type
+	}
+}

--- a/internal/code/module.go
+++ b/internal/code/module.go
@@ -186,7 +186,7 @@ func (h ModuleHandler) ServeModuleMaybe(w http.ResponseWriter, req *http.Request
 		err = z.Close()
 		return err
 	default:
-		return os.ErrNotExist
+		panic("unreachable")
 	}
 }
 

--- a/internal/code/module.go
+++ b/internal/code/module.go
@@ -28,20 +28,24 @@ import (
 )
 
 // ModuleHandler is a Go module server that implements the
-// module proxy protocol. It serves each repository root
-// available in Code as a Go module.
+// module proxy protocol.
 //
 // At this time, it has various limitations compared to the
 // general go mod download functionality that extracts module
 // versions from a VCS repository:
 //
-// 	•	Versions served include only pseudo-versions from
-// 		commits on master branch. Tags and other branches
-// 		are not supported at this time.
-// 	•	Multi-module repositories are not supported at this time.
+// • Versions served include only pseudo-versions from
+// commits on master branch. Tags and other branches
+// are not supported at this time.
+//
+// • Multi-module repositories are not supported at this time.
+//
+// • Major versions other than v0 are not supported at this time.
 //
 // This may change over time as my needs evolve.
 type ModuleHandler struct {
+	// Code is the underlying source of Go code.
+	// Each repository root available in it is served as a Go module.
 	Code *Service
 }
 

--- a/internal/code/module_test.go
+++ b/internal/code/module_test.go
@@ -1,0 +1,148 @@
+package code_test
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/rogpeppe/go-internal/dirhash"
+	"github.com/shurcooL/home/httputil"
+	"github.com/shurcooL/home/internal/code"
+	"github.com/shurcooL/home/internal/mod"
+)
+
+func TestModuleHandler(t *testing.T) {
+	notifications := mockNotifications{}
+	events := &mockEvents{}
+	users := mockUsers{}
+	service, err := code.NewService(filepath.Join("testdata", "repositories"), notifications, events, users)
+	if err != nil {
+		t.Fatal("code.NewService:", err)
+	}
+	moduleHandler := code.ModuleHandler{Code: service}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+		if ok := httputil.ErrorHandleMaybe(w, req, nil, moduleHandler.ServeModuleMaybe); ok {
+			return
+		}
+		t.Error("HTTP server got a non-module proxy request")
+		http.NotFound(w, req)
+	})
+
+	for _, tt := range []struct {
+		url        string
+		wantType   string
+		wantBody   string
+		wantSum    string // Expected checksum for module .zip (as in go.sum).
+		wantModSum string // Expected checksum for go.mod file (as in go.sum).
+	}{
+		// Module emptyrepo tests.
+		{
+			url:      "/emptyrepo/@v/list",
+			wantType: "text/plain; charset=utf-8",
+			wantBody: "",
+		},
+
+		// Module kebabcase tests.
+		{
+			url:      "/kebabcase/@v/list",
+			wantType: "text/plain; charset=utf-8",
+			wantBody: `v0.0.0-20170912031248-a1d95f8919b5
+v0.0.0-20170914162131-bf160e40a791
+`,
+		},
+		{
+			url:      "/kebabcase/@v/v0.0.0-20170912031248-a1d95f8919b5.info",
+			wantType: "application/json",
+			wantBody: `{
+	"Version": "v0.0.0-20170912031248-a1d95f8919b5",
+	"Time": "2017-09-12T03:12:48Z"
+}
+`,
+		},
+		{
+			url:      "/kebabcase/@v/v0.0.0-20170914162131-bf160e40a791.info",
+			wantType: "application/json",
+			wantBody: `{
+	"Version": "v0.0.0-20170914162131-bf160e40a791",
+	"Time": "2017-09-14T16:21:31Z"
+}
+`,
+		},
+		{
+			url:        "/kebabcase/@v/v0.0.0-20170912031248-a1d95f8919b5.mod",
+			wantType:   "text/plain; charset=utf-8",
+			wantBody:   "module dmitri.shuralyov.com/kebabcase\n",
+			wantModSum: "h1:zlZLgG71KSMQ+9XWuKJgSRws1h0iMspYv2y69MUzNFo=",
+		},
+		{
+			url:        "/kebabcase/@v/v0.0.0-20170914162131-bf160e40a791.mod",
+			wantType:   "text/plain; charset=utf-8",
+			wantBody:   "module dmitri.shuralyov.com/kebabcase\n",
+			wantModSum: "h1:zlZLgG71KSMQ+9XWuKJgSRws1h0iMspYv2y69MUzNFo=",
+		},
+		{
+			url:      "/kebabcase/@v/v0.0.0-20170912031248-a1d95f8919b5.zip",
+			wantType: "application/zip",
+			wantSum:  "h1:xUU8cZj0tfJxDjfyJ6xLLh6G615T10e16A1mxCoygiI=",
+		},
+		{
+			url:      "/kebabcase/@v/v0.0.0-20170914162131-bf160e40a791.zip",
+			wantType: "application/zip",
+			wantSum:  "h1:Lz+BA1qBebmQ4Ev2oGecFqNFK4jq5orgAPanU0rsL98=",
+		},
+
+		// Module scratch tests.
+		{
+			url:      "/scratch/@v/list",
+			wantType: "text/plain; charset=utf-8",
+			wantBody: `v0.0.0-20171129001319-b205cb69d5d7
+v0.0.0-20180121202958-53695465092b
+v0.0.0-20180125023930-cdbe493822d6
+v0.0.0-20180326031431-f628922a6885
+`,
+		},
+	} {
+		t.Run(tt.url[1:], func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.url, nil)
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+			if got, want := rr.Code, http.StatusOK; got != want {
+				t.Errorf("got status code %d %s, want %d %s", got, http.StatusText(got), want, http.StatusText(want))
+			}
+			if got, want := rr.Header().Get("Content-Type"), tt.wantType; got != want {
+				t.Errorf("got Content-Type header %q, want %q", got, want)
+			}
+			if tt.wantType != "application/zip" {
+				if got, want := rr.Body.String(), tt.wantBody; got != want {
+					t.Errorf("got body:\n%s\nwant:\n%s", got, want)
+				}
+			}
+			if tt.wantSum != "" {
+				gotSum, err := mod.HashZip(bytes.NewReader(rr.Body.Bytes()), dirhash.DefaultHash)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got, want := gotSum, tt.wantSum; got != want {
+					t.Errorf("got sum %q, want %q", got, want)
+				}
+			}
+			if tt.wantModSum != "" {
+				gotModSum, err := dirhash.Hash1([]string{"go.mod"}, func(string) (io.ReadCloser, error) {
+					return ioutil.NopCloser(bytes.NewReader(rr.Body.Bytes())), nil
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got, want := gotModSum, tt.wantModSum; got != want {
+					t.Errorf("got mod sum %q, want %q", got, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/mod/LICENSE
+++ b/internal/mod/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/internal/mod/mod.go
+++ b/internal/mod/mod.go
@@ -1,0 +1,140 @@
+// Package mod exposes select functionality related to module mechanics.
+// Its code is mostly copied from cmd/go/internal/... packages.
+package mod
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/rogpeppe/go-internal/dirhash"
+	"github.com/rogpeppe/go-internal/semver"
+)
+
+// A RevInfo describes a single revision in a module repository.
+type RevInfo struct {
+	Version string    // version string
+	Time    time.Time // commit time
+}
+
+// PseudoVersion returns a pseudo-version for the given major version ("v1")
+// preexisting older tagged version ("" or "v1.2.3" or "v1.2.3-pre"), revision time,
+// and revision identifier (usually a 12-byte commit hash prefix).
+func PseudoVersion(major, older string, t time.Time, rev string) string {
+	if major == "" {
+		major = "v0"
+	}
+	major = strings.TrimSuffix(major, "-unstable") // make gopkg.in/macaroon-bakery.v2-unstable use "v2"
+	segment := fmt.Sprintf("%s-%s", t.UTC().Format("20060102150405"), rev)
+	build := semver.Build(older)
+	older = semver.Canonical(older)
+	if older == "" {
+		return major + ".0.0-" + segment // form (1)
+	}
+	if semver.Prerelease(older) != "" {
+		return older + ".0." + segment + build // form (4), (5)
+	}
+
+	// Form (2), (3).
+	// Extract patch from vMAJOR.MINOR.PATCH
+	v := older[:]
+	i := strings.LastIndex(v, ".") + 1
+	v, patch := v[:i], v[i:]
+
+	// Increment PATCH by adding 1 to decimal:
+	// scan right to left turning 9s to 0s until you find a digit to increment.
+	// (Number might exceed int64, but math/big is overkill.)
+	digits := []byte(patch)
+	for i = len(digits) - 1; i >= 0 && digits[i] == '9'; i-- {
+		digits[i] = '0'
+	}
+	if i >= 0 {
+		digits[i]++
+	} else {
+		// digits is all zeros
+		digits[0] = '1'
+		digits = append(digits, '0')
+	}
+	patch = string(digits)
+
+	// Reassemble.
+	return v + patch + "-0." + segment + build
+}
+
+// ParsePseudoVersion returns the time stamp and the revision identifier
+// of the pseudo-version v.
+// It returns an error if v is not a pseudo-version or if the time stamp
+// embedded in the pseudo-version is not a valid time.
+func ParsePseudoVersion(v string) (_ time.Time, rev string, err error) {
+	timestamp, rev, err := parsePseudoVersion(v)
+	if err != nil {
+		return time.Time{}, "", err
+	}
+	t, err := time.Parse("20060102150405", timestamp)
+	if err != nil {
+		return time.Time{}, "", fmt.Errorf("pseudo-version with malformed time %s: %q", timestamp, v)
+	}
+	return t, rev, nil
+}
+
+func parsePseudoVersion(v string) (timestamp, rev string, err error) {
+	if !isPseudoVersion(v) {
+		return "", "", fmt.Errorf("malformed pseudo-version %q", v)
+	}
+	v = strings.TrimSuffix(v, "+incompatible")
+	j := strings.LastIndex(v, "-")
+	v, rev = v[:j], v[j+1:]
+	i := strings.LastIndex(v, "-")
+	if j := strings.LastIndex(v, "."); j > i {
+		timestamp = v[j+1:]
+	} else {
+		timestamp = v[i+1:]
+	}
+	return timestamp, rev, nil
+}
+
+// isPseudoVersion reports whether v is a pseudo-version.
+func isPseudoVersion(v string) bool {
+	return strings.Count(v, "-") >= 2 && semver.IsValid(v) && pseudoVersionRE.MatchString(v)
+}
+
+var pseudoVersionRE = regexp.MustCompile(`^v[0-9]+\.(0\.0-|\d+\.\d+-([^+]*\.)?0\.)\d{14}-[A-Za-z0-9]+(\+incompatible)?$`)
+
+// AllHex reports whether the revision rev is entirely lower-case hexadecimal digits.
+func AllHex(rev string) bool {
+	for i := 0; i < len(rev); i++ {
+		c := rev[i]
+		if '0' <= c && c <= '9' || 'a' <= c && c <= 'f' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// HashZip is like dirhash.HashZip, but the .zip file
+// it takes can be in memory rather than on disk.
+func HashZip(r *bytes.Reader, hash dirhash.Hash) (string, error) {
+	z, err := zip.NewReader(r, int64(r.Len()))
+	if err != nil {
+		return "", err
+	}
+	var files []string
+	zfiles := make(map[string]*zip.File)
+	for _, file := range z.File {
+		files = append(files, file.Name)
+		zfiles[file.Name] = file
+	}
+	zipOpen := func(name string) (io.ReadCloser, error) {
+		f := zfiles[name]
+		if f == nil {
+			return nil, fmt.Errorf("file %q not found in zip", name) // should never happen
+		}
+		return f.Open()
+	}
+	return hash(files, zipOpen)
+}

--- a/main.go
+++ b/main.go
@@ -198,6 +198,7 @@ func run(ctx context.Context, storeDir, stateFile, analyticsFile string) error {
 	if err != nil {
 		return fmt.Errorf("code.NewService: %v", err)
 	}
+	moduleHandler := codepkg.ModuleHandler{Code: code}
 	gitUsers, err := initGitUsers(users)
 	if err != nil {
 		return fmt.Errorf("initGitUsers: %v", err)
@@ -234,6 +235,10 @@ func run(ctx context.Context, storeDir, stateFile, analyticsFile string) error {
 		// Serve index page.
 		if req.URL.Path == "/" {
 			indexHandler.ServeHTTP(w, req)
+			return
+		}
+		// Serve module proxy protocol requests for existing repos, if the request matches.
+		if ok := httputil.ErrorHandleMaybe(w, req, nil, moduleHandler.ServeModuleMaybe); ok {
 			return
 		}
 		// Serve git protocol requests for existing repos, if the request matches.


### PR DESCRIPTION
This change adds an initial version of a Go module server
that implements the module proxy protocol, as described
at https://golang.org/cmd/go/#hdr-Module_proxy_protocol.

This enables more efficient serving of Go modules, especially in cases
where only the list, .info and .mod endpoints are requested (not .zip).
That happens often: whenever the module isn't actually used in a build,
rather it just happens to be in the module requirement graph.

The module server isn't fully featured and has some known limitations,
but it's enough to cover my current needs. It serves all current module
versions at [dmitri.shuralyov.com/...](https://dmitri.shuralyov.com/...) with identical checksums as the
canonical `go mod download` algorithm. Its feature set may get expanded
as my needs change.

_**Disclaimer:** There are many wildly different ways to implement a server
that speaks the module proxy protocol. Most are much simpler than what
I've done. There are trade-offs, and I've optimized the design for my own
needs. It's also an initial version which may change over time._